### PR TITLE
Update InventoryDragAndDrop.cs

### DIFF
--- a/InventoryDragAndDrop/InventoryDragAndDrop.cs
+++ b/InventoryDragAndDrop/InventoryDragAndDrop.cs
@@ -7,119 +7,235 @@ using UnityEngine.UI;
 namespace InventoryDragAndDrop
 {
     public class InventoryDragAndDrop : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    private GraphicRaycaster _raycaster;
+    private Canvas _canvas;
+    private List<RaycastResult> _raycastResults;
+    private InventorySlot _slot;
+    private InventoryItem _item;
+    private Inventory _inventory;
+    private string _playerID;
+    private InventorySlot _currentlyHoveredSlot;
+
+    [SerializeField] private bool dragOutsideDropsItem;
+    
+    private void Awake()
     {
-        private GraphicRaycaster _raycaster;
-        private Canvas _canvas;
-        private List<RaycastResult> _raycastResults;
-        private InventorySlot _slot;
-        private InventoryItem _item;
-        private Inventory _inventory;
-        private string _playerID;
-        
-        private void Awake()
-        {
-            _raycaster = GetComponent<GraphicRaycaster>();
-            _canvas = GetComponent<Canvas>();
-        }
+        _raycaster = GetComponent<GraphicRaycaster>();
+        _canvas = GetComponent<Canvas>();
+    }
 
-        private void Raycast(PointerEventData eventData)
+    private void Raycast(PointerEventData eventData)
+    {
+        _raycastResults = new List<RaycastResult>();
+        _raycaster.Raycast(eventData, _raycastResults);
+    }
+    
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        _slot = null;
+        Raycast(eventData);
+        foreach (RaycastResult result in _raycastResults)
         {
-            _raycastResults = new List<RaycastResult>();
-            _raycaster.Raycast(eventData, _raycastResults);
-        }
-        
-        public void OnBeginDrag(PointerEventData eventData)
-        {
-            _slot = null;
-            Raycast(eventData);
-            foreach (var result in _raycastResults)
-            {
-                _slot = result.gameObject.GetComponent<InventorySlot>();
-                if (_slot == null) continue;
-                _inventory = _slot.ParentInventoryDisplay.TargetInventory;
-                _playerID = _inventory.PlayerID;
-                _item = _inventory.Content[_slot.Index];
-                if (InventoryItem.IsNull(_item)) _slot = null;
-                return;
-            }
-        }
-        
-        public void OnDrag(PointerEventData eventData)
-        {
-            if (_slot == null) return;
-            var screenPoint = Input.mousePosition;
-            _slot.IconImage.transform.SetParent(transform, false);
-            if (_canvas.worldCamera != null)
-            {
-                screenPoint.z = _canvas.planeDistance;
-                _slot.IconImage.transform.position = _canvas.worldCamera.ScreenToWorldPoint(screenPoint);
-            }
-            else
-                _slot.IconImage.transform.position = screenPoint;
-        }
+            _slot = result.gameObject.GetComponent<InventorySlot>();
+            if (_slot == null) continue;
 
-        public void OnEndDrag(PointerEventData eventData)
-        {
-            if (_slot == null) return;
-            _slot.IconImage.transform.SetParent(_slot.transform, false);
-            _slot.IconImage.transform.localPosition = Vector3.zero;
-            Raycast(eventData);
-            foreach (var result in _raycastResults)
+            if (!_slot.SlotEnabled)
             {
-                var destinationSlot = result.gameObject.GetComponent<InventorySlot>();
-                if (destinationSlot == null) continue;
-                var destinationInventory = destinationSlot.ParentInventoryDisplay.TargetInventory;
-                var destinationItem = destinationInventory.Content[destinationSlot.Index];
-                var isDestinationEmpty = InventoryItem.IsNull(destinationItem);
-                if (_inventory == destinationInventory && (_item.CanMoveObject && isDestinationEmpty || _item.CanSwapObject && !isDestinationEmpty && destinationItem.CanSwapObject))
-                    _inventory.MoveItem(_slot.Index, destinationSlot.Index);
-                else if (_item.IsEquippable && _item.TargetEquipmentInventoryName == destinationInventory.name)
+                continue;
+            }
+            
+            if (InventoryItem.IsNull(_slot.CurrentItem))
+            {
+                _slot = null;
+                continue;
+            }
+            
+            if (!_slot.CurrentItem.CanMoveObject)
+            {
+                _slot = null;
+                continue;
+            }
+            
+            _inventory = _slot.ParentInventoryDisplay.TargetInventory;
+            _playerID = _inventory.PlayerID;
+            _item = _inventory.Content[_slot.Index];
+            return;
+        }
+    }
+    
+    public void OnDrag(PointerEventData eventData)
+    {
+        if (_slot == null) return;
+        Vector3 screenPoint = Input.mousePosition;
+        _slot.IconImage.transform.SetParent(transform, false);
+        if (_canvas.worldCamera != null)
+        {
+            screenPoint.z = _canvas.planeDistance;
+            _slot.IconImage.transform.position = _canvas.worldCamera.ScreenToWorldPoint(screenPoint);
+        }
+        else
+        {
+            _slot.IconImage.transform.position = screenPoint;
+        }
+        
+        //Highlighting slots the item is getting dragged over
+        Raycast(eventData);
+        InventorySlot newHoveredSlot = null;
+        
+        foreach (RaycastResult result in _raycastResults)
+        {
+            newHoveredSlot = result.gameObject.GetComponent<InventorySlot>();
+            if (newHoveredSlot != null) break; 
+        }
+        
+        if (newHoveredSlot != _currentlyHoveredSlot)
+        {
+            //remove highlight from old slot
+            if (_currentlyHoveredSlot != null)
+            {
+                _currentlyHoveredSlot.OnPointerExit(eventData);
+            }
+
+            //highlight new slot
+            if (newHoveredSlot != null)
+            {
+                newHoveredSlot.OnPointerEnter(eventData);
+            }
+
+            _currentlyHoveredSlot = newHoveredSlot;
+        }
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (_currentlyHoveredSlot)
+        {
+            _currentlyHoveredSlot.OnPointerExit(eventData);
+            _currentlyHoveredSlot = null;
+        }
+        
+        if (_slot == null) return;
+        _slot.IconImage.transform.SetParent(_slot.transform, false);
+        _slot.IconImage.transform.localPosition = Vector3.zero;
+        
+        Raycast(eventData);
+        
+        //Validation (especially for move) to work like original Move method using buttons
+        foreach (RaycastResult result in _raycastResults)
+        {
+            InventorySlot destinationSlot = result.gameObject.GetComponent<InventorySlot>();
+            if (destinationSlot == null) continue;
+
+            InventoryDisplay destinationDisplay = destinationSlot.ParentInventoryDisplay;
+            Inventory destinationInventory = destinationDisplay.TargetInventory;
+            
+            if (!destinationSlot.SlotEnabled) return;
+            
+            InventoryItem destinationItem = destinationInventory.Content[destinationSlot.Index];
+            bool isDestinationEmpty = InventoryItem.IsNull(destinationItem);
+
+            bool moveSuccessful = false;
+
+            //Moving within the same inventory
+            if (_inventory == destinationInventory)
+            {
+                if ((_item.CanMoveObject && isDestinationEmpty) ||
+                    (_item.CanSwapObject && !isDestinationEmpty && destinationItem.CanSwapObject))
                 {
-                    if (isDestinationEmpty)
+                    moveSuccessful = _inventory.MoveItem(_slot.Index, destinationSlot.Index);
+                }
+            }
+            //Moving from Inventory to Equipment Inventory (equip item)
+            else if (_item.IsEquippable && _item.TargetEquipmentInventoryName == destinationInventory.name)
+            {
+                if (isDestinationEmpty)
+                {
+                    _item.Equip(_playerID);
+                    moveSuccessful = _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
+                    if (moveSuccessful)
                     {
-                        _item.Equip(_playerID);
-                        _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
                         MMInventoryEvent.Trigger(MMInventoryEventType.ItemEquipped, destinationSlot, destinationInventory.name, _item, 0, destinationSlot.Index, _playerID);
                     }
-                    else
-                    {
-                        destinationItem.UnEquip(_playerID);
-                        _item.Equip(_playerID);
-                        var tempItem = destinationItem.Copy();
-                        destinationInventory.Content[destinationSlot.Index] = _item.Copy();
-                        _inventory.Content[_slot.Index] = tempItem;
-                        MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, _inventory.name, null, 0, 0, _playerID);
-                        MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
-                    }
                 }
-                else if (_slot.Unequippable() && _item.TargetInventoryName == destinationInventory.name)
+                else if (destinationItem.CanSwapObject)
+                {
+                    destinationItem.UnEquip(_playerID);
+                    _item.Equip(_playerID);
+            
+                    InventoryItem tempItem = destinationItem.Copy();
+                    destinationInventory.Content[destinationSlot.Index] = _item.Copy();
+                    _inventory.Content[_slot.Index] = tempItem;
+            
+                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, _inventory.name, null, 0, 0, _playerID);
+                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
+                    moveSuccessful = true;
+                }
+            }
+            //Moving from Equipment Inventory to main Inventory (unequip item)
+            else if (_slot.Unequippable() && _item.TargetInventoryName == destinationInventory.name)
+            {
+                if (isDestinationEmpty)
+                {
+                    _item.UnEquip(_playerID);
+                    moveSuccessful = _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
+                }
+                else if (destinationItem.IsEquippable && destinationItem.TargetEquipmentInventoryName == _inventory.name)
+                {
+                    _item.UnEquip(_playerID);
+                    destinationItem.Equip(_playerID);
+            
+                    InventoryItem tempItem = _item.Copy();
+                    _inventory.Content[_slot.Index] = destinationItem.Copy();
+                    destinationInventory.Content[destinationSlot.Index] = tempItem;
+            
+                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
+                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, _inventory.name, null, 0, 0, _playerID);
+                    moveSuccessful = true;
+                }
+            }
+            //Inventory switch (for example Main Inventory to chest - Main Inventory to Main Inventory)
+            else if (_inventory != destinationInventory)
+            {
+                if (destinationDisplay.AllowMovingObjectsToThisInventory)
                 {
                     if (isDestinationEmpty)
                     {
-                        _item.UnEquip(_playerID);
-                        _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
+                        moveSuccessful = _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
                     }
-                    else if (destinationItem.IsEquippable && destinationItem.TargetEquipmentInventoryName == _inventory.name)
+                    else if (_item.CanSwapObject && destinationItem.CanSwapObject)
                     {
-                        _item.UnEquip(_playerID);
-                        destinationItem.Equip(_playerID);
-                        var tempItem = _item.Copy();
-                        _inventory.Content[_slot.Index] = destinationItem.Copy();
-                        destinationInventory.Content[destinationSlot.Index] = tempItem;
-                        MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
+                        InventoryItem tempItem = destinationItem.Copy();
+                        destinationInventory.Content[destinationSlot.Index] = _item.Copy();
+                        _inventory.Content[_slot.Index] = tempItem;
+                        moveSuccessful = true;
+                    }
+                    
+                    if (moveSuccessful)
+                    {
                         MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, _inventory.name, null, 0, 0, _playerID);
+                        MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
                     }
                 }
-                else if (_inventory != destinationInventory && isDestinationEmpty)
-                {
-                    _inventory.MoveItemToInventory(_slot.Index, destinationInventory, destinationSlot.Index);
-                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, _inventory.name, null, 0, 0, _playerID);
-                    MMInventoryEvent.Trigger(MMInventoryEventType.ContentChanged, null, destinationInventory.name, null, 0, 0, _playerID);
-                }
-
-                return;
             }
+
+            if (moveSuccessful)
+            {
+                MMInventoryEvent.Trigger(MMInventoryEventType.Move, destinationSlot, destinationInventory.name, destinationInventory.Content[destinationSlot.Index], 0, destinationSlot.Index, _playerID);
+                destinationSlot.Select();
+            }
+            else
+            {
+                MMInventoryEvent.Trigger(MMInventoryEventType.Error, destinationSlot, destinationInventory.name, null, 0, destinationSlot.Index, _playerID);
+            }
+            
+            return;
+        }
+
+        if (dragOutsideDropsItem)
+        {
             _slot.Drop();
         }
     }
+}
 }


### PR DESCRIPTION
Fixes:
- Immovable Items can't be moved/grabbed anymore (and put into other inventories)
- Items can't be dragged to the wrong Inventory anymore (like for example in the PixelRogueRoom demo - Coins to Armor slot or anything else that wouldn't work using the move button)
- Items can't be dragged from disabled slots anymore
- Items can't be dropped onto disabled slots anymore

Visual: 
- Slots under the dragged item get highlighted, so it's clearly visible where you're dropping an item
- Target slot gets auto selected after successfully moving an object (which feels more natural imo)

Behavior:
- Added a toggle "dragOutsideDropsItem" to make the forced Item Drop optional for the user when releasing the mouse outside of a slot. The current drop can be a little frustrating as it drops the item from the inventory if you accidentally drop it between two slots so i thought it should rather be an option